### PR TITLE
Add Heading and Text components with viewport based size

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,7 @@
       }
     ],
     "react/jsx-filename-extension": "off",
+    "react/prefer-stateless-function": "off",
     "jsx-a11y/anchor-is-valid": [
       "error",
       {

--- a/src/components/Footer/index.scss
+++ b/src/components/Footer/index.scss
@@ -67,8 +67,8 @@
 
   font-family: $font-family-serif;
   font-size: $size-small;
-  line-height: $size-base;
-};
+  line-height: $size-small;
+}
 
 .Footer-logo {
   padding: 2px;
@@ -77,9 +77,8 @@
   color: $color-deep-blue;
 
   font-family: $font-family-mono;
-  font-size: $size-xsmall;
+  font-size: $font-size-xsmall;
   font-weight: $font-weight-bold;
-  line-height: $size-small;
-  vertical-align: text-bottom;
+
   white-space: nowrap;
 }

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -14,6 +14,8 @@
   background-color: $color-deep-blue;
 
   color: white;
+
+  line-height: 1;
 }
 
 .Header-left {

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -63,6 +63,11 @@
 }
 
 @media only screen and (max-width: 800px) {
+  .Header {
+    padding-right: $size-base;
+    padding-left: $size-base;
+  }
+
   .Header-sections {
     display: none;
   }

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -15,7 +15,7 @@
 
   color: white;
 
-  line-height: 1;
+  line-height: $line-height-medium;
 }
 
 .Header-left {

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -63,10 +63,6 @@
 }
 
 @media only screen and (max-width: 800px) {
-  .Header {
-    padding: $size-base;
-  }
-
   .Header-sections {
     display: none;
   }

--- a/src/components/Heading/index.js
+++ b/src/components/Heading/index.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import "./index.scss";
+
+export default class Heading extends React.Component {
+  static propTypes = {
+    level: PropTypes.oneOf(["1", "2", "3", "4", "5"]),
+    weight: PropTypes.oneOf(["light", "regular", "bold"]),
+    children: PropTypes.node.isRequired,
+  };
+
+  static defaultProps = {
+    level: "1",
+    weight: "bold",
+  };
+
+  render() {
+    const { level, weight, children } = this.props;
+    const HeadingComponent = `h${level}`;
+
+    return (
+      <HeadingComponent className={`Heading-${weight} Heading-level${level}`}>
+        {children}
+      </HeadingComponent>
+    );
+  }
+}

--- a/src/components/Heading/index.scss
+++ b/src/components/Heading/index.scss
@@ -17,21 +17,21 @@
 }
 
 .Heading-level1 {
-  font-size: 2em;
+  font-size: $font-size-xlarge;
 }
 
 .Heading-level2 {
-  font-size: 1.5em;
+  font-size: $font-size-large;
 }
 
 .Heading-level3 {
-  font-size: 1.17em;
+  font-size: $font-size-medium;
 }
 
 .Heading-level4 {
-  font-size: 1em;
+  font-size: $font-size-small;
 }
 
 .Heading-level5 {
-  font-size: .83em;
+  font-size: $font-size-xsmall;
 }

--- a/src/components/Heading/index.scss
+++ b/src/components/Heading/index.scss
@@ -1,0 +1,37 @@
+@import "../../styles/variables.scss";
+
+.Heading-light {
+  font-weight: $font-weight-light;
+}
+
+.Heading-regular {
+  font-weight: $font-weight-regular;
+}
+
+.Heading-bold {
+  font-weight: $font-weight-bold;
+}
+
+.Heading-xsmall {
+  font-size: $font-size-xsmall;
+}
+
+.Heading-level1 {
+  font-size: 2em;
+}
+
+.Heading-level2 {
+  font-size: 1.5em;
+}
+
+.Heading-level3 {
+  font-size: 1.17em;
+}
+
+.Heading-level4 {
+  font-size: 1em;
+}
+
+.Heading-level5 {
+  font-size: .83em;
+}

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import "./index.scss";
+
+export default class Text extends React.Component {
+  static propTypes = {
+    size: PropTypes.oneOf(["xsmall", "small", "medium", "large", "xlarge"]),
+    weight: PropTypes.oneOf(["light", "regular", "bold"]),
+    children: PropTypes.node.isRequired,
+  };
+
+  static defaultProps = {
+    size: "small",
+    weight: "regular",
+  };
+
+  render() {
+    const { size, weight, children } = this.props;
+
+    return <p className={`Text-${weight} Text-${size}`}>{children}</p>;
+  }
+}

--- a/src/components/Text/index.scss
+++ b/src/components/Text/index.scss
@@ -1,0 +1,33 @@
+@import "../../styles/variables.scss";
+
+.Text-light {
+  font-weight: $font-weight-light;
+}
+
+.Text-regular {
+  font-weight: $font-weight-regular;
+}
+
+.Text-bold {
+  font-weight: $font-weight-bold;
+}
+
+.Text-xsmall {
+  font-size: $font-size-xsmall;
+}
+
+.Text-small {
+  font-size: $font-size-small;
+}
+
+.Text-medium {
+  font-size: $font-size-medium;
+}
+
+.Text-large {
+  font-size: $font-size-large;
+}
+
+.Text-xlarge {
+  font-size: $font-size-xlarge;
+}

--- a/src/layouts/index.scss
+++ b/src/layouts/index.scss
@@ -1,6 +1,8 @@
 @import "../styles/variables.scss";
 
-html { font-size: calc(80% + 0.5vw) }
+html {
+  font-size: calc(80% + 0.5vw);
+}
 
 body {
   width: 100%;
@@ -13,6 +15,7 @@ body {
 
 .Content {
   max-width: 960px;
+  padding-top: calc(#{$size-xxlarge} + #{$line-height-small});
   padding-right: $size-base;
   padding-left: $size-base;
   margin: 0 auto;
@@ -21,28 +24,4 @@ body {
 section {
   min-height: 300px;
   padding-bottom: $size-xxlarge;
-}
-
-@media all and (min-width: 960px) {
-  .Content {
-    padding-top: calc(
-      #{$size-xxlarge} + (#{$size-base}*2) + #{$line-height-small}
-    );
-  }
-}
-
-@media all and (max-width: 959px) and (min-width: 600px) {
-  .Content {
-    padding-top: calc(
-      #{$size-xlarge} + (#{$size-base}*2) + #{$line-height-small}
-    );
-  }
-}
-
-@media all and (max-width: 599px) {
-  .Content {
-    padding-top: calc(
-      #{$size-large} + (#{$size-base}*2) + #{$line-height-xsmall}
-    );
-  }
 }

--- a/src/layouts/index.scss
+++ b/src/layouts/index.scss
@@ -1,7 +1,7 @@
 @import "../styles/variables.scss";
 
 html {
-  font-size: calc(80% + 0.5vw);
+  font-size: calc(80% + 0.2vw);
 }
 
 body {

--- a/src/layouts/index.scss
+++ b/src/layouts/index.scss
@@ -1,11 +1,14 @@
 @import "../styles/variables.scss";
 
-body {
+html { font-size: calc(80% + 0.5vw) }
 
+body {
   width: 100%;
 
   font-family: $font-family-mono;
   font-weight: $font-weight-regular;
+
+  line-height: 1.5;
 }
 
 .Content {
@@ -16,28 +19,19 @@ body {
 }
 
 section {
-  height: 300px;
+  min-height: 300px;
+  padding-bottom: $size-xxlarge;
 }
 
 @media all and (min-width: 960px) {
-  body {
-    font-size: $font-size-small;
-    line-height: $line-height-medium;
-  }
-
   .Content {
     padding-top: calc(
-      #{$size-xxlarge} + (#{$size-base}*2) + #{$line-height-medium}
+      #{$size-xxlarge} + (#{$size-base}*2) + #{$line-height-small}
     );
   }
 }
 
 @media all and (max-width: 959px) and (min-width: 600px) {
-  body {
-    font-size: $font-size-small;
-    line-height: $line-height-small;
-  }
-
   .Content {
     padding-top: calc(
       #{$size-xlarge} + (#{$size-base}*2) + #{$line-height-small}
@@ -46,11 +40,6 @@ section {
 }
 
 @media all and (max-width: 599px) {
-  body {
-    font-size: $font-size-xsmall;
-    line-height: $line-height-xsmall;
-  }
-
   .Content {
     padding-top: calc(
       #{$size-large} + (#{$size-base}*2) + #{$line-height-xsmall}

--- a/src/sections/Section1/index.js
+++ b/src/sections/Section1/index.js
@@ -1,17 +1,20 @@
 import React from "react";
+import Heading from "../../components/Heading";
+import Text from "../../components/Text";
 
 export default function Section1() {
   return (
     <section id="section1">
-      <h1> Section1 </h1>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nisi quam,
-        feugiat vel congue vel, lacinia id erat. In suscipit risus ipsum, non
-        imperdiet massa aliquet euismod. Nullam aliquam urna in lorem sagittis
-        ultrices. Nunc efficitur lacus diam. Sed venenatis feugiat scelerisque.
-        Duis faucibus rhoncus ligula, ac pellentesque urna feugiat sit amet.
-        Duis in vulputate nunc.
-      </p>
+      <Heading level="1">Section1</Heading>
+      <Text size="medium" weight="bold">
+        Medium size bold text
+      </Text>
+
+      <Text>Default size text</Text>
+
+      <Text size="small" weight="light">
+        Small size light text
+      </Text>
     </section>
   );
 }

--- a/src/sections/Section2/index.js
+++ b/src/sections/Section2/index.js
@@ -1,17 +1,19 @@
 import React from "react";
+import Heading from "../../components/Heading";
+import Text from "../../components/Text";
 
 export default function Section2() {
   return (
     <section id="section2">
-      <h1> Section2 </h1>
-      <p>
+      <Heading level="1">Section2</Heading>
+      <Text>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nisi quam,
         feugiat vel congue vel, lacinia id erat. In suscipit risus ipsum, non
         imperdiet massa aliquet euismod. Nullam aliquam urna in lorem sagittis
         ultrices. Nunc efficitur lacus diam. Sed venenatis feugiat scelerisque.
         Duis faucibus rhoncus ligula, ac pellentesque urna feugiat sit amet.
         Duis in vulputate nunc.
-      </p>
+      </Text>
     </section>
   );
 }

--- a/src/sections/Section3/index.js
+++ b/src/sections/Section3/index.js
@@ -1,17 +1,19 @@
 import React from "react";
+import Heading from "../../components/Heading";
+import Text from "../../components/Text";
 
 export default function Section3() {
   return (
     <section id="section3">
-      <h1> Section3 </h1>
-      <p>
+      <Heading level="1">Section3</Heading>
+      <Text>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nisi quam,
         feugiat vel congue vel, lacinia id erat. In suscipit risus ipsum, non
         imperdiet massa aliquet euismod. Nullam aliquam urna in lorem sagittis
         ultrices. Nunc efficitur lacus diam. Sed venenatis feugiat scelerisque.
         Duis faucibus rhoncus ligula, ac pellentesque urna feugiat sit amet.
         Duis in vulputate nunc.
-      </p>
+      </Text>
     </section>
   );
 }

--- a/src/sections/Section4/index.js
+++ b/src/sections/Section4/index.js
@@ -1,17 +1,19 @@
 import React from "react";
+import Heading from "../../components/Heading";
+import Text from "../../components/Text";
 
 export default function Section4() {
   return (
     <section id="section4">
-      <h1> Section4 </h1>
-      <p>
+      <Heading level="1">Section4</Heading>
+      <Text>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nisi quam,
         feugiat vel congue vel, lacinia id erat. In suscipit risus ipsum, non
         imperdiet massa aliquet euismod. Nullam aliquam urna in lorem sagittis
         ultrices. Nunc efficitur lacus diam. Sed venenatis feugiat scelerisque.
         Duis faucibus rhoncus ligula, ac pellentesque urna feugiat sit amet.
         Duis in vulputate nunc.
-      </p>
+      </Text>
     </section>
   );
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -8,13 +8,13 @@ $color-red: #f95252;
 $color-white: #ffffff;
 $color-yellow: #e5c650;
 
-$size-xxsmall: 8px;
-$size-xsmall: 12px;
-$size-small: 16px;
-$size-base: 24px;
-$size-large: 40px;
-$size-xlarge: 64px;
-$size-xxlarge: 84px;
+$size-xxsmall: 0.5em;
+$size-xsmall: 0.75em;
+$size-small: 1em;
+$size-base: 1.25em;
+$size-large: 2em;
+$size-xlarge: 3em;
+$size-xxlarge: 5em;
 
 $max-tablet-size: 768px;
 
@@ -24,16 +24,16 @@ $grid-size: 992px;
 
 $font-family-mono: 'Fira Mono', monospace;
 $font-family-serif: 'Merriweather', serif;
-$font-size-xsmall: 12px;
-$font-size-small: 16px;
-$font-size-medium: 20px;
-$font-size-large: 28px;
-$font-size-xlarge: 36px;
-$line-height-xsmall: 16px;
-$line-height-small: 20px;
-$line-height-medium: 28px;
-$line-height-large: 36px;
-$line-height-xlarge: 52px;
+$font-size-xsmall: 0.75em;
+$font-size-small: 1em;
+$font-size-medium: 1.25em;
+$font-size-large: 1.75em;
+$font-size-xlarge: 2.25em;
+$line-height-xsmall: calc(0.75em * 1.618);
+$line-height-small: calc(1em * 1.618);
+$line-height-medium: calc(1.25em * 1.618);
+$line-height-large: calc(1.75em * 1.618);
+$line-height-xlarge: calc(2.25em * 1.618);
 $font-weight-light: 300;
 $font-weight-regular: 400;
 $font-weight-bold: 700;


### PR DESCRIPTION
This PR adds the Heading and Text components which replace `h1`-`h5` and `p` elements. Also changes up the font scaling to use `em` and set the base font-size to a a percentage of the viewport width.

Also removed the `prefer stateless` rule from the linter. I believe that with class properties the components become much more readable. Performance benefits are not that beneficial, and still needs some more investigation.